### PR TITLE
Fix https intercepts. Add https test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 build/
 .tox
 **/__pycache__
+**/.pytest_cache

--- a/aresponses/main.py
+++ b/aresponses/main.py
@@ -92,19 +92,17 @@ class ResponsesMockServer(BaseTestServer):
 
         TCPConnector._resolve_host = _resolver_mock
 
-        self._old_update_host = ClientRequest.update_host
+        self._old_is_ssl = ClientRequest.is_ssl
 
-        def new_update_host(_self, *args, **kwargs):
-            val = self._old_update_host(_self, *args, **kwargs)
-            _self._ssl = False
-            return val
+        def new_is_ssl(_self):
+            return False
 
-        ClientRequest.update_host = new_update_host
+        ClientRequest.is_ssl = new_is_ssl
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         TCPConnector._resolve_host = self._old_resolver_mock
-        ClientRequest.update_host = self._old_update_host
+        ClientRequest.is_ssl = self._old_is_ssl
 
         await self.close()
         if self._exception:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-__version__ = '0.2'
+__version__ = '0.2.1'
 
 setup(
     name="aresponses",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,6 +16,17 @@ async def test_fixture(aresponses):
 
 
 @pytest.mark.asyncio
+async def test_https(aresponses):
+    aresponses.add('foo.com', '/', 'get', aresponses.Response(text='hi'))
+
+    url = 'https://foo.com'
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as response:
+            text = await response.text()
+    assert text == 'hi'
+
+
+@pytest.mark.asyncio
 async def test_context_manager(event_loop):
     async with aresponses.ResponsesMockServer(loop=event_loop) as arsps:
         arsps.add('foo.com', '/', 'get', aresponses.Response(text='hi'))


### PR DESCRIPTION
This lets the library intercept https again.  It broke when aiohttp updated to 3.0