### PR TITLE
Use pytest.fixture instead of pytest.yield_fixture, as the latter is deprecated

### DIFF
--- a/aresponses/main.py
+++ b/aresponses/main.py
@@ -133,7 +133,7 @@ class ResponsesMockServer(BaseTestServer):
             raise self._exception  # noqa
 
 
-@pytest.yield_fixture
+@pytest.fixture
 async def aresponses(event_loop):
     async with ResponsesMockServer(loop=event_loop) as server:
         yield server


### PR DESCRIPTION
From https://docs.pytest.org/en/latest/yieldfixture.html:
```
Since pytest-3.0, fixtures using the normal fixture decorator can use a yield statement to provide fixture values and execute teardown code, exactly like yield_fixture in previous versions.

Marking functions as yield_fixture is still supported, but deprecated and should not be used in new code.
```