### PR TITLE
passthrough support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,4 @@ async def test_foo(event_loop):
 * Bryce Drennan, CircleUp <aresponses@brycedrennan.com>
 * Marco Castelluccio, Mozilla <mcastelluccio@mozilla.com>
 * Jesse Vogt, CircleUp <jesse.vogt@gmail.com>
-* [p4l1ly](https://github.com/p4l1ly)
+* Pavol Vargovcik, Kiwi.com <pavol.vargovcik@gmail.com>

--- a/aresponses/__init__.py
+++ b/aresponses/__init__.py
@@ -1,2 +1,2 @@
 from aiohttp.web import Response  # noqa
-from aresponses.main import aresponses, ResponsesMockServer
+from aresponses.main import aresponses, PassThrough, ResponsesMockServer

--- a/aresponses/__init__.py
+++ b/aresponses/__init__.py
@@ -1,2 +1,2 @@
 from aiohttp.web import Response  # noqa
-from aresponses.main import aresponses, PassThrough, ResponsesMockServer
+from aresponses.main import aresponses, ResponsesMockServer

--- a/aresponses/main.py
+++ b/aresponses/main.py
@@ -1,10 +1,9 @@
 import asyncio
-from functools import partial
 import logging
+from functools import partial
 
 import pytest
-import aiohttp
-from aiohttp import web
+from aiohttp import web, ClientSession
 from aiohttp.client_reqrep import ClientRequest
 from aiohttp.connector import TCPConnector
 from aiohttp.helpers import sentinel
@@ -39,7 +38,7 @@ class RawResponse(StreamResponse):
         await super().write_eof(self._body)
 
 
-class PassThrough:
+class PassThrough(object):
     pass
 
 
@@ -92,38 +91,15 @@ class ResponsesMockServer(BaseTestServer):
         for host_pattern, path_pattern, method_pattern, response, match_querystring in self._responses:
             if _text_matches_pattern(host_pattern, host):
                 host_matched = True
-                if (not match_querystring and _text_matches_pattern(path_pattern, path)) or\
-                   (match_querystring and _text_matches_pattern(path_pattern, path_qs)):
+                if (not match_querystring and _text_matches_pattern(path_pattern, path)) or \
+                        (match_querystring and _text_matches_pattern(path_pattern, path_qs)):
                     path_matched = True
                     if _text_matches_pattern(method_pattern, method.lower()):
-                        if response is PassThrough:
-                            connector = TCPConnector()
-                            connector._resolve_host = partial(self._old_resolver_mock, connector)
-
-                            new_is_ssl = ClientRequest.is_ssl
-                            ClientRequest.is_ssl = self._old_is_ssl
-                            try:
-                                original_request = request.clone(
-                                    scheme='https' if request.headers['AResponsesIsSSL'] else 'http')
-
-                                headers = {k: v for k, v in request.headers.items() if k != 'AResponsesIsSSL'}
-
-                                async with aiohttp.ClientSession(connector=connector) as session:
-                                    async with getattr(session, method.lower())(
-                                        original_request.url, headers=headers,
-                                        data=(await request.read())
-                                    ) as r:
-                                        headers = {k: v for k, v in r.headers.items() if k.lower() == 'content-type'}
-                                        text = await r.text()
-                                        response = self.Response(
-                                            text=text, status=r.status, headers=headers)
-                                        return response
-                            finally:
-                                ClientRequest.is_ssl = new_is_ssl
-
                         del self._responses[i]
 
-                        if callable(response):
+                        if response is PassThrough:
+                            return await self.make_real_request(request)
+                        elif callable(response):
                             if asyncio.iscoroutinefunction(response):
                                 return await response(request)
                             return response(request)
@@ -134,6 +110,32 @@ class ResponsesMockServer(BaseTestServer):
         self._exception = Exception(f"No Match found for {host} {path} {method}.  Host Match: {host_matched}  Path Match: {path_matched}")
         self._loop.stop()
         raise self._exception  # noqa
+
+    async def make_network_request(self, request):
+        """Make non-mocked network request"""
+        connector = TCPConnector()
+        connector._resolve_host = partial(self._old_resolver_mock, connector)
+
+        new_is_ssl = ClientRequest.is_ssl
+        ClientRequest.is_ssl = self._old_is_ssl
+        try:
+            original_request = request.clone(
+                scheme='https' if request.headers['AResponsesIsSSL'] else 'http')
+
+            headers = {k: v for k, v in request.headers.items() if k != 'AResponsesIsSSL'}
+
+            async with ClientSession(connector=connector) as session:
+                async with getattr(session, request.method.lower())(
+                        original_request.url, headers=headers,
+                        data=(await request.read())
+                ) as r:
+                    headers = {k: v for k, v in r.headers.items() if k.lower() == 'content-type'}
+                    text = await r.text()
+                    response = self.Response(
+                        text=text, status=r.status, headers=headers)
+                    return response
+        finally:
+            ClientRequest.is_ssl = new_is_ssl
 
     async def __aenter__(self):
         await self.start_server(loop=self._loop)
@@ -155,6 +157,7 @@ class ResponsesMockServer(BaseTestServer):
 
         ClientRequest.is_ssl = new_is_ssl
 
+        # store whether a request was an SSL request in the `AResponsesIsSSL` header
         self._old_init = ClientRequest.__init__
 
         def new_init(_self, *largs, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # dev/testing requirements
-pytest
+pytest==3.6.4
 pytest-asyncio
 pytest-xdist
 pydocstyle

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 setup(
     name="aresponses",


### PR DESCRIPTION
If the response type is PassThrough, the test server acts as a proxy.
This is not bullet-proof, with use of e.g. asyncio.gather, things can
mess up (but it was a problem even with the code before this commit).

From the remote server's headers, only the "Content-Type" is preserved
(which is enough in many cases). Other headers are filtered out because
may cause problems (for example content-encoding).

The PassThrough supports HTTPS. The support is maybe not very clean but it
works. The information about HTTPS usage in the client's request is
added to the request as a header, then the HTTPS is suppressed
(the request is converted to HTTP, as it was before this commit). The
proxy server reads the HTTPS information from the headers and modifies
the request's scheme according to it.