### PR TITLE
Make responses reusable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ matrix:
       env: TEST_CMD="make test"
     - python: "3.7"
       env: TEST_CMD="make lint"
+    - python: "3.8"
+      env: TEST_CMD="make test"
+    - python: "3.8"
+      env: TEST_CMD="make lint"
 script: $TEST_CMD
 after_success:
   - codecov

--- a/aresponses/main.py
+++ b/aresponses/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from copy import copy
 from functools import partial
 
 import pytest
@@ -80,7 +81,6 @@ class ResponsesMockServer(BaseTestServer):
     async def _find_response(self, request):
         host, path, path_qs, method = request.host, request.path, request.path_qs, request.method
         logger.info(f"Looking for match for {host} {path} {method}")  # noqa
-        i = 0
         host_matched = False
         path_matched = False
         for host_pattern, path_pattern, method_pattern, response, match_querystring in self._responses:
@@ -91,7 +91,7 @@ class ResponsesMockServer(BaseTestServer):
                 ):
                     path_matched = True
                     if _text_matches_pattern(method_pattern, method.lower()):
-                        del self._responses[i]
+                        response = copy(response)
 
                         if callable(response):
                             if asyncio.iscoroutinefunction(response):
@@ -102,7 +102,6 @@ class ResponsesMockServer(BaseTestServer):
                             return self.Response(body=response)
 
                         return response
-            i += 1
         self._exception = Exception(f"No Match found for {host} {path} {method}.  Host Match: {host_matched}  Path Match: {path_matched}")
         self._loop.stop()
         raise self._exception  # noqa

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -186,3 +186,15 @@ async def test_passthrough(aresponses):
         async with session.get(url) as response:
             text = await response.text()
     assert text == "200 OK"
+
+
+@pytest.mark.asyncio
+async def test_reusable(aresponses):
+    aresponses.add(aresponses.ANY, aresponses.ANY, aresponses.ANY, "hi", is_reusable=True)
+
+    url = "http://foo.com"
+    for _ in range(2):
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                text = await response.text()
+        assert text == "hi"


### PR DESCRIPTION
This makes it possible to define session-wide
mocks to intercept requests.  The response object
is single-use so we need to make a copy of it
after finding a match.