### PR TITLE
fix: allow mocking https subrequests. remove pytest-asyncio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint:  ## Run the code linter.
 
 deploy:  ## Deploy the package to pypi.org
 	pip install twine wheel
-	git tag $$(python setup.py -V)
+	#git tag $$(python setup.py -V)
 	git push --tags
 	python setup.py bdist_wheel
 	python setup.py sdist

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ when you need do something more complex.
 
 **Note that version >=2.0 requires explicit assertions!**
 ```python
-@pytest.mark.asyncio
+
 async def test_simple(aresponses):
     aresponses.add("google.com", "/api/v1/", "GET", response="OK")
     aresponses.add('foo.com', '/', 'get', aresponses.Response(text='error', status=500))
@@ -93,7 +93,7 @@ times its called you could set repeat to a large number and not call
 `arespones.assert_no_unused_routes`.
 
 ```python
-@pytest.mark.asyncio
+
 async def test_regex_repetition(aresponses):
     aresponses.add(re.compile(r".*\.?google\.com"), response="OK", repeat=2)
 
@@ -115,7 +115,7 @@ create a json response. A `aiohttp.web_response.json_response` object
 can be used for more complex situations.
 
 ```python
-@pytest.mark.asyncio
+
 async def test_json(aresponses):
     aresponses.add("google.com", "/api/v1/", "GET", response={"status": "OK"})
 
@@ -135,7 +135,7 @@ and always return 500.
 ```python
 import math
 
-@pytest.mark.asyncio
+
 async def test_handler(aresponses):
     def break_everything(request):
         return aresponses.Response(status=500, text=str(request.url))
@@ -161,7 +161,7 @@ History of calls can be inspected via `aresponses.history` which returns
 the namedTuple `RoutingLog(request, route, response)`
 
 ```python
-@pytest.mark.asyncio
+
 async def test_history(aresponses):
     aresponses.add(response=aresponses.Response(text="hi"), repeat=2)
 
@@ -184,13 +184,13 @@ import aiohttp
 import pytest
 import aresponses
 
-@pytest.mark.asyncio
-async def test_foo(event_loop):
-    async with aresponses.ResponsesMockServer(loop=event_loop) as arsps:
+
+async def test_foo(loop):
+    async with aresponses.ResponsesMockServer(loop=loop) as arsps:
         arsps.add('foo.com', '/', 'get', 'hi there!!')
         arsps.add(arsps.ANY, '/', 'get', arsps.Response(text='hey!'))
         
-        async with aiohttp.ClientSession(loop=event_loop) as session:
+        async with aiohttp.ClientSession(loop=loop) as session:
             async with session.get('http://foo.com') as response:
                 text = await response.text()
                 assert text == 'hi'

--- a/aresponses/main.py
+++ b/aresponses/main.py
@@ -183,24 +183,28 @@ class ResponsesMockServer(BaseTestServer):
 
     async def passthrough(self, request):
         """Make non-mocked network request"""
-        connector = TCPConnector()
-        connector._resolve_host = partial(self._old_resolver_mock, connector)
 
-        new_is_ssl = ClientRequest.is_ssl
-        ClientRequest.is_ssl = self._old_is_ssl
-        try:
-            original_request = request.clone(scheme="https" if request.headers["AResponsesIsSSL"] else "http")
+        class DirectTcpConnector(TCPConnector):
+            def _resolve_host(slf, *args, **kwargs):
+                return self._old_resolver_mock(slf, *args, **kwargs)
 
-            headers = {k: v for k, v in request.headers.items() if k != "AResponsesIsSSL"}
+        class DirectClientRequest(ClientRequest):
+            def is_ssl(slf) -> bool:
+                return slf._aresponses_direct_is_ssl()
 
-            async with ClientSession(connector=connector) as session:
-                async with getattr(session, request.method.lower())(original_request.url, headers=headers, data=(await request.read())) as r:
-                    headers = {k: v for k, v in r.headers.items() if k.lower() == "content-type"}
-                    data = await r.read()
-                    response = self.Response(body=data, status=r.status, headers=headers)
-                    return response
-        finally:
-            ClientRequest.is_ssl = new_is_ssl
+        connector = DirectTcpConnector()
+
+        original_request = request.clone(scheme="https" if request.headers["AResponsesIsSSL"] else "http")
+
+        headers = {k: v for k, v in request.headers.items() if k != "AResponsesIsSSL"}
+
+        async with ClientSession(connector=connector, request_class=DirectClientRequest) as session:
+            request_method = getattr(session, request.method.lower())
+            async with request_method(original_request.url, headers=headers, data=(await request.read())) as r:
+                headers = {k: v for k, v in r.headers.items() if k.lower() == "content-type"}
+                data = await r.read()
+                response = self.Response(body=data, status=r.status, headers=headers)
+                return response
 
     async def __aenter__(self) -> "ResponsesMockServer":
         await self.start_server(loop=self._loop)
@@ -213,6 +217,7 @@ class ResponsesMockServer(BaseTestServer):
         TCPConnector._resolve_host = _resolver_mock
 
         self._old_is_ssl = ClientRequest.is_ssl
+        ClientRequest._aresponses_direct_is_ssl = ClientRequest.is_ssl
 
         def new_is_ssl(_self):
             return False
@@ -263,6 +268,6 @@ class ResponsesMockServer(BaseTestServer):
 
 
 @pytest.fixture
-async def aresponses(event_loop) -> ResponsesMockServer:
-    async with ResponsesMockServer(loop=event_loop) as server:
+async def aresponses(loop) -> ResponsesMockServer:
+    async with ResponsesMockServer(loop=loop) as server:
         yield server

--- a/requirements.in
+++ b/requirements.in
@@ -6,5 +6,4 @@ pylava==0.2.2
 pylava-pylint==0.0.3
 pylint==2.4.4
 pytest==5.3.1
-pytest-asyncio==0.10.0
 pytest-cov==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,9 @@
 #    pip-compile --output-file=requirements.txt requirements.in setup.py
 #
 aiohttp==3.7.3
-    # via aresponses (setup.py)
+    # via
+    #   aresponses (setup.py)
+    #   pytest-aiohttp
 appdirs==1.4.4
     # via black
 astroid==2.3.3
@@ -77,16 +79,14 @@ pylint==2.4.4
     #   pylava-pylint
 pyparsing==2.4.7
     # via packaging
-pytest-asyncio==0.10.0
-    # via
-    #   -r requirements.in
-    #   aresponses (setup.py)
+pytest-aiohttp==0.3.0
+    # via aresponses (setup.py)
 pytest-cov==2.8.1
     # via -r requirements.in
 pytest==5.3.1
     # via
     #   -r requirements.in
-    #   pytest-asyncio
+    #   pytest-aiohttp
     #   pytest-cov
 six==1.15.0
     # via astroid

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     python_requires=">=3.6",
-    install_requires=["aiohttp==3.*,>=3.1.0", "pytest-asyncio"],
+    install_requires=["aiohttp==3.*,>=3.1.0", "pytest-aiohttp"],
     # the following makes a plugin available to pytest
     entry_points={"pytest11": ["name_of_plugin = aresponses.main"]},
 )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,11 +1,9 @@
 import math
 import re
 
-import pytest
 import aiohttp
 
 
-@pytest.mark.asyncio
 async def test_simple(aresponses):
     aresponses.add("google.com", "/api/v1/", "GET", response="OK")
     aresponses.add("foo.com", "/", "get", aresponses.Response(text="error", status=500))
@@ -22,7 +20,6 @@ async def test_simple(aresponses):
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_regex_repetition(aresponses):
     aresponses.add(re.compile(r".*\.?google\.com"), response="OK", repeat=2)
 
@@ -38,7 +35,6 @@ async def test_regex_repetition(aresponses):
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_json(aresponses):
     aresponses.add("google.com", "/api/v1/", "GET", response={"status": "OK"})
 
@@ -49,7 +45,6 @@ async def test_json(aresponses):
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_handler(aresponses):
     def break_everything(request):
         return aresponses.Response(status=500, text=str(request.url))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,7 +9,6 @@ import aresponses as aresponses_mod
 from aresponses.errors import NoRouteFoundError, UnusedRouteError, UnorderedRouteCallError
 
 
-@pytest.mark.asyncio
 async def test_foo(aresponses):
     # text as response (defaults to status 200 response)
     aresponses.add("foo.com", "/", "get", "hi there!!")
@@ -55,7 +54,6 @@ async def test_foo(aresponses):
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_fixture(aresponses):
     aresponses.add("foo.com", "/", "get", aresponses.Response(text="hi"))
 
@@ -68,7 +66,6 @@ async def test_fixture(aresponses):
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_body_match(aresponses):
     aresponses.add("foo.com", "/", "get", aresponses.Response(text="hi"), body_pattern=re.compile(r".*?apple.*"))
 
@@ -84,7 +81,6 @@ async def test_body_match(aresponses):
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_https(aresponses):
     aresponses.add("foo.com", "/", "get", aresponses.Response(text="hi"))
 
@@ -97,9 +93,8 @@ async def test_https(aresponses):
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
-async def test_context_manager(event_loop):
-    async with aresponses_mod.ResponsesMockServer(loop=event_loop) as arsps:
+async def test_context_manager(loop):
+    async with aresponses_mod.ResponsesMockServer(loop=loop) as arsps:
         arsps.add("foo.com", "/", "get", aresponses_mod.Response(text="hi"))
 
         url = "http://foo.com"
@@ -111,7 +106,6 @@ async def test_context_manager(event_loop):
     arsps.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_bad_redirect(aresponses):
     aresponses.add("foo.com", "/", "get", aresponses.Response(text="hi", status=301))
     url = "http://foo.com"
@@ -122,7 +116,6 @@ async def test_bad_redirect(aresponses):
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_regex(aresponses):
     aresponses.add(aresponses.ANY, aresponses.ANY, aresponses.ANY, aresponses.Response(text="hi"))
     aresponses.add(aresponses.ANY, aresponses.ANY, aresponses.ANY, aresponses.Response(text="there"))
@@ -139,7 +132,6 @@ async def test_regex(aresponses):
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_callable(aresponses):
     def handler(request):
         return aresponses.Response(body=request.host)
@@ -159,7 +151,6 @@ async def test_callable(aresponses):
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_raw_response(aresponses):
     raw_response = b"""HTTP/1.1 200 OK\r
 Date: Tue, 26 Dec 2017 05:47:50 GMT\r
@@ -176,7 +167,6 @@ Date: Tue, 26 Dec 2017 05:47:50 GMT\r
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_querystring(aresponses):
     aresponses.add("foo.com", "/path", "get", aresponses.Response(text="hi"))
 
@@ -197,7 +187,6 @@ async def test_querystring(aresponses):
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_querystring_not_match(aresponses):
     aresponses.add("foo.com", "/path", "get", aresponses.Response(text="hi"), match_querystring=True)
     aresponses.add("foo.com", aresponses.ANY, "get", aresponses.Response(text="miss"), match_querystring=True)
@@ -224,7 +213,6 @@ async def test_querystring_not_match(aresponses):
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_passthrough(aresponses):
     aresponses.add("httpstat.us", "/200", "get", aresponses.passthrough)
 
@@ -237,7 +225,6 @@ async def test_passthrough(aresponses):
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_failure_not_called(aresponses):
     aresponses.add("foo.com", "/", "get", aresponses.Response(text="hi"))
     with pytest.raises(UnusedRouteError):
@@ -247,7 +234,6 @@ async def test_failure_not_called(aresponses):
         aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_failure_no_match(aresponses):
     async with aiohttp.ClientSession() as session:
         try:
@@ -262,7 +248,6 @@ async def test_failure_no_match(aresponses):
         aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_failure_bad_ordering(aresponses):
     aresponses.add("foo.com", "/a", "get", aresponses.Response(text="hi"))
     aresponses.add("foo.com", "/b", "get", aresponses.Response(text="hi"))
@@ -282,7 +267,6 @@ async def test_failure_bad_ordering(aresponses):
         aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_failure_not_called_enough_times(aresponses):
     aresponses.add("foo.com", "/", "get", aresponses.Response(text="hi"), repeat=2)
 
@@ -294,7 +278,6 @@ async def test_failure_not_called_enough_times(aresponses):
         aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_history(aresponses):
     aresponses.add(response=aresponses.Response(text="hi"), repeat=2)
 
@@ -311,7 +294,6 @@ async def test_history(aresponses):
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
 async def test_history_post(aresponses):
     """Ensure the request contets exist in the history"""
     aresponses.add(method_pattern="POST", response={"some": "response"})

--- a/tests/test_with_aiohttp_server.py
+++ b/tests/test_with_aiohttp_server.py
@@ -1,0 +1,69 @@
+import aiohttp
+import pytest
+from aiohttp import web
+
+from aresponses import ResponsesMockServer
+
+
+def make_app():
+    app = web.Application()
+
+    async def constant_handler(request):
+        return web.Response(text="42")
+
+    async def ip_handler(request):
+        protocol = request.query["protocol"]
+        ip = await get_ip_address(protocol=protocol)
+        return web.Response(text=f"ip is {ip}")
+
+    app.add_routes([web.get("/constant", constant_handler)])
+    app.add_routes([web.get("/ip", ip_handler)])
+    return app
+
+
+async def get_ip_address(protocol):
+    async with aiohttp.ClientSession() as s:
+        async with s.get(f"{protocol}://httpbin.org/ip") as resp:
+            ip = (await resp.json())["origin"]
+            return ip
+
+
+@pytest.fixture(name="aresponses")
+async def aresponses_fixture(loop):
+    async with ResponsesMockServer(loop=loop) as server:
+        yield server
+
+
+async def test_app_simple_endpoint(aiohttp_client):
+    client = await aiohttp_client(make_app())
+    r = await client.get("/constant")
+    assert (await r.text()) == "42"
+
+
+async def test_app_simple_endpoint_with_aresponses(aiohttp_client, aresponses):
+    """
+    when testing your own aiohttp server you must setup passthrough to it
+
+    Ideally this wouldn't be necessary but haven't figured that out yet.
+    Perhaps all local calls should be passthrough.
+    """
+    aresponses.add("127.0.0.1:4241", response=aresponses.passthrough)
+
+    client = await aiohttp_client(make_app(), server_kwargs={"port": 4241})
+    r = await client.get("/constant")
+    assert (await r.text()) == "42"
+
+
+@pytest.mark.parametrize("protocol", ["http", "https"])
+async def test_app_with_subrequest_using_aresponses(aiohttp_client, aresponses, protocol):
+    """
+    but passthrough doesn't work if the handler itself makes an aiohttp https request
+    """
+    aresponses.add("127.0.0.1:4241", response=aresponses.passthrough)
+    aresponses.add("httpbin.org", response={"origin": "1.2.3.4"})
+
+    client = await aiohttp_client(make_app(), server_kwargs={"port": 4241})
+    r = await client.get(f"/ip?protocol={protocol}")
+    body = await r.text()
+    assert r.status == 200, body
+    assert "ip is" in (await r.text())

--- a/tests/test_with_aiohttp_server.py
+++ b/tests/test_with_aiohttp_server.py
@@ -51,10 +51,10 @@ async def test_app_with_subrequest_using_aresponses(aiohttp_client, aresponses, 
     """
     but passthrough doesn't work if the handler itself makes an aiohttp https request
     """
-    aresponses.add("127.0.0.1:4241", response=aresponses.passthrough)
+    aresponses.add_local_passthrough(repeat=1)
     aresponses.add("httpbin.org", response={"origin": "1.2.3.4"})
 
-    client = await aiohttp_client(make_app(), server_kwargs={"port": 4241})
+    client = await aiohttp_client(make_app())
     r = await client.get(f"/ip?protocol={protocol}")
     body = await r.text()
     assert r.status == 200, body

--- a/tests/test_with_aiohttp_server.py
+++ b/tests/test_with_aiohttp_server.py
@@ -2,8 +2,6 @@ import aiohttp
 import pytest
 from aiohttp import web
 
-from aresponses import ResponsesMockServer
-
 
 def make_app():
     app = web.Application()
@@ -26,12 +24,6 @@ async def get_ip_address(protocol):
         async with s.get(f"{protocol}://httpbin.org/ip") as resp:
             ip = (await resp.json())["origin"]
             return ip
-
-
-@pytest.fixture(name="aresponses")
-async def aresponses_fixture(loop):
-    async with ResponsesMockServer(loop=loop) as server:
-        yield server
 
 
 async def test_app_simple_endpoint(aiohttp_client):
@@ -67,3 +59,4 @@ async def test_app_with_subrequest_using_aresponses(aiohttp_client, aresponses, 
     body = await r.text()
     assert r.status == 200, body
     assert "ip is" in (await r.text())
+    aresponses.assert_plan_strictly_followed()

--- a/tox.ini
+++ b/tox.ini
@@ -15,5 +15,4 @@ source=aresponses
 
 [pytest]
 addopts = --doctest-modules -s --tb=native
-collect_ignore = setup.py
 norecursedirs = build dist


### PR DESCRIPTION
Fixes #51 and fixes #52

BREAKING CHANGE! These changes make it so that aresponses will no longer work if pytest-asyncio is installed

Two changes were necessary to support https subrequests:

1. Removing pytest-asyncio as a dependency was necessary or the subrequest test would just hang indefinitely. Not sure why entirely but it's known that pytest-asyncio and aiohttp don't play nicely.

2. The is_ssl was monkeypatched in a synchronous way that couldn't work when simultaneous requests needed it both patched and not-patched.  Instead of undoing the ClientRequest monkey-patching we make DirectClientRequest and have our passthrough session use it instead.

I also added a convenience function `add_local_passthrough`. it's useful when working with your own application server or other local resources.  To work with `assert_plan_strictly_followed` you should pass in the number of times it will be called as the `repeat` argument.  You can see how it's used in the new tests.

@elupus Thanks for pointing me in the right direction. @Zopieux  I think this resolves the issue you encountered. I would appreciate you both taking a look over this if you have a chance.  I'm a little concerned about this library going from dependent on `pytest-asyncio` to totally incompatible with it even being installed.  Any ideas about how we can preserve compatibility?

Update: #56 is a pytest-asyncio compatible solution to this.