### PR TITLE
fix: https passthrough. aiohttp_client compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ import aiohttp
 import pytest
 import aresponses
 
+
 @pytest.mark.asyncio
 async def test_foo(event_loop):
     async with aresponses.ResponsesMockServer(loop=event_loop) as arsps:
@@ -211,6 +212,15 @@ from aresponses import ResponsesMockServer
 async def aresponses(loop):
     async with ResponsesMockServer(loop=loop) as server:
         yield server
+```
+
+If you're trying to use the `aiohttp_client` test fixture then you'll need to mock out the aiohttp `loop` fixture
+instead:
+```python
+@pytest.fixture
+def loop(event_loop):
+    """replace aiohttp loop fixture with pytest-asyncio fixture"""
+    return event_loop
 ```
 
 ## Contributing

--- a/aresponses/main.py
+++ b/aresponses/main.py
@@ -1,5 +1,7 @@
 import asyncio
 import logging
+import math
+import re
 from copy import copy
 from typing import List, NamedTuple
 
@@ -91,6 +93,8 @@ class ResponsesMockServer(BaseTestServer):
     ANY = ANY
     Response = web.Response
     RawResponse = RawResponse
+    INFINITY = math.inf
+    LOCALHOST = re.compile(r"127\.0\.0\.1:?\d{0,5}")
 
     def __init__(self, *, scheme=sentinel, host="127.0.0.1", **kwargs):
         self._responses = []
@@ -147,6 +151,9 @@ class ResponsesMockServer(BaseTestServer):
             )
 
         self._responses.append((route, response))
+
+    def add_local_passthrough(self, repeat=INFINITY):
+        self.add(host_pattern=self.LOCALHOST, repeat=repeat, response=self.passthrough)
 
     async def _find_response(self, request):
         for i, (route, response) in enumerate(self._responses):
@@ -242,10 +249,10 @@ class ResponsesMockServer(BaseTestServer):
 
         await self.close()
 
-    def assert_no_unused_routes(self):
-        if self._responses:
-            route, _ = self._responses[0]
-            raise UnusedRouteError(f"Unused Route: {route}")
+    def assert_no_unused_routes(self, ignore_infinite_repeats=False):
+        for route, _ in self._responses:
+            if not ignore_infinite_repeats or route.repeat != self.INFINITY:
+                raise UnusedRouteError(f"Unused Route: {route}")
 
     def assert_called_in_order(self):
         if self._first_unordered_route is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
 from aresponses import aresponses
 
 assert aresponses
+
+pytest_plugins = "aiohttp.pytest_plugin"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,8 +1,8 @@
 import math
 import re
 
-import pytest
 import aiohttp
+import pytest
 
 
 @pytest.mark.asyncio

--- a/tests/test_with_aiohttp_client.py
+++ b/tests/test_with_aiohttp_client.py
@@ -60,10 +60,10 @@ async def test_app_with_subrequest_using_aresponses(aiohttp_client, aresponses, 
     """
     but passthrough doesn't work if the handler itself makes an aiohttp https request
     """
-    aresponses.add("127.0.0.1:4241", response=aresponses.passthrough)
+    aresponses.add_local_passthrough(repeat=1)
     aresponses.add("httpbin.org", response={"origin": "1.2.3.4"})
 
-    client = await aiohttp_client(make_app(), server_kwargs={"port": 4241})
+    client = await aiohttp_client(make_app())
     r = await client.get(f"/ip?protocol={protocol}")
     body = await r.text()
     assert r.status == 200, body

--- a/tests/test_with_aiohttp_server.py
+++ b/tests/test_with_aiohttp_server.py
@@ -1,0 +1,69 @@
+import aiohttp
+import pytest
+from aiohttp import web
+
+from aresponses import ResponsesMockServer
+
+
+def make_app():
+    app = web.Application()
+
+    async def constant_handler(request):
+        return web.Response(text="42")
+
+    async def ip_handler(request):
+        protocol = request.query["protocol"]
+        ip = await get_ip_address(protocol=protocol)
+        return web.Response(text=f"ip is {ip}")
+
+    app.add_routes([web.get("/constant", constant_handler)])
+    app.add_routes([web.get("/ip", ip_handler)])
+    return app
+
+
+async def get_ip_address(protocol):
+    async with aiohttp.ClientSession() as s:
+        async with s.get(f"{protocol}://httpbin.org/ip") as resp:
+            ip = (await resp.json())["origin"]
+            return ip
+
+
+@pytest.fixture(name="aresponses")
+async def aresponses_fixture(loop):
+    async with ResponsesMockServer(loop=loop) as server:
+        yield server
+
+
+async def test_app_simple_endpoint(aiohttp_client):
+    client = await aiohttp_client(make_app())
+    r = await client.get("/constant")
+    assert (await r.text()) == "42"
+
+
+async def test_app_simple_endpoint_with_aresponses(aiohttp_client, aresponses):
+    """
+    when testing your own aiohttp server you must setup passthrough to it
+
+    Ideally this wouldn't be necessary but haven't figured that out yet.
+    Perhaps all local calls should be passthrough.
+    """
+    aresponses.add("127.0.0.1:4241", response=aresponses.passthrough)
+
+    client = await aiohttp_client(make_app(), server_kwargs={"port": 4241})
+    r = await client.get("/constant")
+    assert (await r.text()) == "42"
+
+
+@pytest.mark.parametrize("protocol", ["http", "https"])
+async def test_app_with_subrequest_using_aresponses(aiohttp_client, aresponses, protocol):
+    """
+    but passthrough doesn't work if the handler itself makes an aiohttp https request
+    """
+    aresponses.add("127.0.0.1:4241", response=aresponses.passthrough)
+    aresponses.add("httpbin.org", response={"origin": "1.2.3.4"})
+
+    client = await aiohttp_client(make_app(), server_kwargs={"port": 4241})
+    r = await client.get(f"/ip?protocol={protocol}")
+    body = await r.text()
+    assert r.status == 200, body
+    assert "ip is" in (await r.text())


### PR DESCRIPTION
This is an alternative to #55 that maintains compatibility with pytest-asyncio and fixes #51 and fixes #52.

The `is_ssl` method was monkey-patched in a synchronous way that couldn't work when simultaneous requests needed it both patched and not-patched.  Instead of undoing the ClientRequest monkey-patching we create DirectClientRequest and have our passthrough session use it instead.

For compatibility between aresponses and aiohttp_client fixtures we use a work-around recommended by @serjshevchenko  (https://github.com/pytest-dev/pytest-asyncio/issues/170#issuecomment-706114516) that replaces the aiohttp_client loop fixture with the event loop provided by pytest-asycnio.  The hanging was caused by different fixtures running on different event loops.

Workaround example:
```python
@pytest.fixture
def loop(event_loop):
    """replace aiohttp loop fixture with pytest-asyncio fixture"""
    return event_loop
```

Also added `add_local_passthrough` which is useful when working with your own application server or other local resources.  To work with `assert_plan_strictly_followed` you should pass in the number of times it will be called as the `repeat` argument.

It's equivalent to
```python
LOCALHOST = re.compile(r"127\.0\.0\.1:?\d{0,5}")
aresponses.add(
    host_pattern=LOCALHOST,
    repeat=aresponses.INFINITY,
    response=aresponses.passthrough
    )
```

@elupus @Zopieux I think I prefer this solution over #55 although it does require the developer to manually override the `loop` fixture.  I'll leave these pull requests open for a few days to give you both an opportunity to comment.